### PR TITLE
Fix dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -42,11 +42,17 @@ Initial release with basic Init/Quit Open and Close Font and render solid text
  <dependencies>
   <required>
    <php>
-    <min>7.0.0</min>
+    <min>7.3.0</min>
    </php>
    <pearinstaller>
-    <min>1.4.3</min>
+    <min>1.10</min>
    </pearinstaller>
+   <package>
+    <name>sdl</name>
+    <channel>pecl.php.net</channel>
+    <min>2.3.0</min>
+    <providesextension>sdl</providesextension>
+   </package>
   </required>
  </dependencies>
  <providesextension>sdl_ttf</providesextension>


### PR DESCRIPTION
Adding dependency on **sdl** extension, as

```
$ php -n -d extension=sdl_ttf -v

Warning: PHP Startup: Unable to load dynamic library 'sdl_ttf' (tried: /usr/lib64/php/modules/sdl_ttf (/usr/lib64/php/modules/sdl_ttf: cannot open shared object file: No such file or directory), /usr/lib64/php/modules/sdl_ttf.so (/usr/lib64/php/modules/sdl_ttf.so: undefined symbol: zval_to_sdl_color)) in Unknown on line 0
```

And `zval_to_sdl_color` is provided by **sdl** extension

Also bumping to PHP 7.3 (required by sdl) and pear 1.10 (first version to support PHP 7)
